### PR TITLE
Improve context name display

### DIFF
--- a/packages/devtool-extenstion/extension/core/hook.js
+++ b/packages/devtool-extenstion/extension/core/hook.js
@@ -174,14 +174,15 @@ export function installHook(target) {
       fiberNodeToDebug.context[debugId] &&
       node.pendingProps.value === fiberNodeToDebug.context[debugId].value
     );
-
+  
+    const displayName =  node.pendingProps.displayName || node.type._context.displayName;
+    const value = node.pendingProps.value;
+    const debugName = value && (Object.keys(value).slice(0, 3).join(", ") + (value.length > 3 ? " ..." : ""));
+    
     fiberNodeToDebugCopy.context[debugId] = {
       valueChanged,
-      value: node.pendingProps.value,
-      displayName:
-        node.pendingProps.displayName ||
-        node.type._context.displayName ||
-        debugId,
+      value,
+      displayName: displayName || debugName || debugId,
     };
   };
 

--- a/packages/devtool-extenstion/src/containers/Sidebar/index.scss
+++ b/packages/devtool-extenstion/src/containers/Sidebar/index.scss
@@ -3,7 +3,7 @@ aside {
   flex-direction: column;
   background-color: var(--sidebar-bg-color);
   border-right: 1px solid var(--border-color);
-  width: 250px;
+  width: 275px;
 
   .filters {
     align-items: center;
@@ -32,7 +32,7 @@ aside {
       font-size: 0.9rem;
       padding: 1rem 1rem 1.5rem;
       position: relative;
-      word-break: break-all;
+      overflow-wrap: break-word;
 
       &:hover,
       &.selected {


### PR DESCRIPTION
This improves how contexts that are not explicitely named (e.g. `debug_id8` etc.) are displayed in the sidebar.
The idea was to simply show the first three keys of the context object. By this you usually get a pretty good idea about what context it is. 

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot 2021-02-09 at 18 07 56](https://user-images.githubusercontent.com/15912049/107481694-e5c6e280-6b7e-11eb-9015-3b77a356ab53.png)  |  ![Screenshot 2021-02-09 at 18 07 17](https://user-images.githubusercontent.com/15912049/107481697-e8293c80-6b7e-11eb-9e80-7dc764b7d48c.png)


