### PR TITLE
Fix font size issue

### DIFF
--- a/packages/devtool-extenstion/src/components/JsonEditor/index.scss
+++ b/packages/devtool-extenstion/src/components/JsonEditor/index.scss
@@ -1,7 +1,6 @@
 .json-editor {
   flex: 1;
   overflow: auto;
-  font-size: 1rem;
   height: 100%;
 
   .CodeMirror {

--- a/packages/devtool-extenstion/src/components/JsonTree/index.scss
+++ b/packages/devtool-extenstion/src/components/JsonTree/index.scss
@@ -6,11 +6,10 @@
     overflow: auto;
     background-color: var(--view-bg-color) !important;
     padding: 1rem;
-    font-size: 1rem;
 
     .copy-icon {
       svg {
-        font-size: 1rem !important;
+        font-size: inherit !important;
       }
     }
   }

--- a/packages/devtool-extenstion/src/containers/ContextView/index.scss
+++ b/packages/devtool-extenstion/src/containers/ContextView/index.scss
@@ -22,5 +22,6 @@
   .data-view {
     flex: 1;
     overflow: auto;
+    font-size: 12px;
   }
 }


### PR DESCRIPTION
On chrome the font was to big (16px) in json tree and json editor.
Changed it to 12px.
I've only tested it on chrome.
Firefox seems to be having a different font size...