### PR TITLE
Properly Detect Circular Structures Fixes #31, #28

### DIFF
--- a/packages/devtool-extenstion/extension/core/injectGlobalHook.js
+++ b/packages/devtool-extenstion/extension/core/injectGlobalHook.js
@@ -55,6 +55,8 @@ function injectHelpers(target) {
   };
 
   const parseData = (data) => {
+    //For Detecting Circular Structures
+    const seen = new WeakSet();
     const stringifyResolver = function (k, v) {
       if (typeof v === "function") {
         return "function () {}";
@@ -76,6 +78,13 @@ function injectHelpers(target) {
       }
       if (isReactNode(k, v)) {
         return "<REACT NODE>";
+      }
+      //Detect Circular Structure
+      if (typeof v === "object" && v !== null) {
+        if (seen.has(v)) {
+          return "Circular Structure";
+        }
+        seen.add(v);
       }
       return v;
     };


### PR DESCRIPTION
Properly Detect Circular Structures. This fixes #31 and also fixes #28. I now see tons more contexts that were previously hidden because of Circular Structure errors

When a Circular Structure is encountered then "Circular Structure" is printed.

Idea derived from: https://stackoverflow.com/a/55545121/16201934

![image](https://user-images.githubusercontent.com/564256/122132476-c8857780-cdef-11eb-9134-71b281f45568.png)
